### PR TITLE
fix: restricciones de permisos para cursos

### DIFF
--- a/Backend/src/controllers/cursos.controller.js
+++ b/Backend/src/controllers/cursos.controller.js
@@ -269,7 +269,7 @@ exports.finalize = async (req, res) => {
         JOIN usuario u ON i.cedula_estudiante = u.cedula
         WHERE i.id_curso = ? 
           AND i.estado = 'aprobado'
-          AND NOT EXISTS (SELECT 1 FROM certificados c WHERE c.id_inscripcion = i.id_inscripcion)
+          AND NOT EXISTS (SELECT 1 FROM certificado c WHERE c.id_inscripcion = i.id_inscripcion)
     `, [req.params.id]);
 
     // 4. Generar registros de Certificados
@@ -277,7 +277,7 @@ exports.finalize = async (req, res) => {
     for (const insc of inscripciones) {
       const code = uuidv4();
       await pool.query(
-        'INSERT INTO certificados (id_inscripcion, codigo_verificacion) VALUES (?, ?)',
+        'INSERT INTO certificado (id_inscripcion, codigo_verificacion) VALUES (?, ?)',
         [insc.id_inscripcion, code]
       );
       generated++;

--- a/Frontend/src/modules/cursos/FormCurso.jsx
+++ b/Frontend/src/modules/cursos/FormCurso.jsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Select from 'react-select';
 import { API } from '../../services/api';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 
 const isTenDigits = (v) => /^[0-9]{10}$/.test(v || '');
 
@@ -20,7 +21,10 @@ const PUBLICO_OPTIONS = [
   { value: 'Público General', label: 'Público General' },
 ];
 
-export default function FormCurso({ initial = {}, onSaved, auth }) {
+export default function FormCurso({ initial = {}, onSaved }) {
+  const { user, token } = useAuth();
+  // alias auth param to token if needed by API calls that expect 'auth'
+  const auth = token;
   const [data, setData] = useState({
     cedula_responsable: initial.cedula_responsable || '',
     cedula_docente: initial.cedula_docente || '',
@@ -53,6 +57,13 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
 
   const [mensaje, setMensaje] = useState(null);
   const navigate = useNavigate();
+
+  // Determine if locked (Active course + Restriction rule)
+  // Logic: Locked if Active AND not Finalized (allow finalizing elsewhere maybe? No, changes restricted)
+  // "Reglas de curso solo modificables cuando el curso está inhabilitado"
+  // If no 'inactivo' prop, we infer active if it has an ID and state indicates active.
+  // We prioritize 'initial.estado' if available, otherwise check !inactivo if available.
+  const isLocked = initial.estado === 'activo' || (initial.id_curso && initial.inactivo === false && initial.estado !== 'finalizado');
 
   useEffect(() => {
     API.listUsuarios({}, auth).then(setUsuarios);
@@ -170,6 +181,11 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
 
   return (
     <form onSubmit={save} className="space-y-5">
+      {isLocked && (
+        <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 p-4 rounded-lg text-sm mb-4">
+          <strong>Modo Lectura:</strong> Este curso está activo. Para modificar reglas críticas (fechas, horas, costos), primero debe desactivarlo.
+        </div>
+      )}
       {mensaje && (
         <div className={`rounded p-3 text-sm ${mensaje.tipo === 'exito' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'}`}>
           {mensaje.texto}
@@ -204,10 +220,11 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
       <div>
         <label className={labelClass}>Nombre del curso</label>
         <input
-          className={inputClass}
+          className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
           value={data.nombre}
           onChange={(e) => setData({ ...data, nombre: e.target.value })}
           required
+          disabled={isLocked}
         />
         {errors.nombre && <p className="text-xs text-red-600 mt-1">{errors.nombre}</p>}
       </div>
@@ -228,9 +245,10 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
         <div>
           <label className={labelClass}>Tipo</label>
           <select
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             value={data.tipo}
             onChange={(e) => setData({ ...data, tipo: e.target.value })}
+            disabled={isLocked}
           >
             <option value="">Selecciona</option>
             <option value="Curso">Curso</option>
@@ -241,12 +259,13 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
         <div>
           <label className={labelClass}>Horas</label>
           <input
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             type="number"
             min={1}
             value={data.horas}
             onChange={(e) => setData({ ...data, horas: e.target.value })}
             placeholder="Ej. 20"
+            disabled={isLocked}
           />
           {errors.horas && <p className="text-xs text-red-600 mt-1">{errors.horas}</p>}
         </div>
@@ -266,6 +285,7 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
           onInputChange={(val, meta) => { if (meta.action === 'input-change') fetchCursos(val || ''); }}
           isClearable
           placeholder="Buscar curso existente..."
+          isDisabled={isLocked}
         />
       </div>
 
@@ -278,6 +298,7 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
           value={publicoValue}
           onChange={(opts) => setData(d => ({ ...d, publico_objetivo: (opts || []).map(o => o.value) }))}
           placeholder="Selecciona uno o más"
+          isDisabled={isLocked}
         />
       </div>
 
@@ -286,22 +307,24 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
         <div>
           <label className={labelClass}>Nota de aprobación</label>
           <input
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             type="number"
             min={0}
             max={10}
             step="0.1"
             value={data.nota_aprobacion}
             onChange={(e) => setData({ ...data, nota_aprobacion: e.target.value })}
+            disabled={isLocked}
           />
           {errors.nota_aprobacion && <p className="text-xs text-red-600 mt-1">{errors.nota_aprobacion}</p>}
         </div>
         <div>
           <label className={labelClass}>Requiere asistencia</label>
           <select
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             value={String(data.requiere_asistencia)}
             onChange={(e) => setData({ ...data, requiere_asistencia: e.target.value === 'true' })}
+            disabled={isLocked}
           >
             <option value="true">Sí</option>
             <option value="false">No</option>
@@ -313,9 +336,10 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
       <div>
         <label className={labelClass}>Es pagado</label>
         <select
-          className={inputClass}
+          className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
           value={String(data.es_pagado)}
           onChange={(e) => setData({ ...data, es_pagado: e.target.value === 'true' })}
+          disabled={isLocked}
         >
           <option value="false">No</option>
           <option value="true">Sí</option>
@@ -325,13 +349,14 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
         <div>
           <label className={labelClass}>Costo (USD)</label>
           <input
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             type="number"
             min="0"
             step="0.01"
             value={data.costo}
             onChange={(e) => setData({ ...data, costo: e.target.value })}
             placeholder="Ej. 120.00"
+            disabled={isLocked}
           />
           {errors.costo && <p className="text-xs text-red-600 mt-1">{errors.costo}</p>}
         </div>
@@ -343,18 +368,20 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
           <label className={labelClass}>Fecha inicio</label>
           <input
             type="date"
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             value={data.fecha_inicio}
             onChange={(e) => setData({ ...data, fecha_inicio: e.target.value })}
+            disabled={isLocked}
           />
         </div>
         <div>
           <label className={labelClass}>Fecha fin</label>
           <input
             type="date"
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             value={data.fecha_fin}
             onChange={(e) => setData({ ...data, fecha_fin: e.target.value })}
+            disabled={isLocked}
           />
           {errors.fecha_fin && <p className="text-xs text-red-600 mt-1">{errors.fecha_fin}</p>}
         </div>
@@ -366,18 +393,20 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
           <label className={labelClass}>Fecha Inicio Inscripción</label>
           <input
             type="date"
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             value={data.fecha_inicio_inscripcion}
             onChange={(e) => setData({ ...data, fecha_inicio_inscripcion: e.target.value })}
+            disabled={isLocked}
           />
         </div>
         <div>
           <label className={labelClass}>Fecha Fin Inscripción</label>
           <input
             type="date"
-            className={inputClass}
+            className={`${inputClass} ${isLocked ? 'bg-gray-100 cursor-not-allowed' : ''}`}
             value={data.fecha_fin_inscripcion}
             onChange={(e) => setData({ ...data, fecha_fin_inscripcion: e.target.value })}
+            disabled={isLocked}
           />
           {errors.fecha_fin_inscripcion && <p className="text-xs text-red-600 mt-1">{errors.fecha_fin_inscripcion}</p>}
         </div>
@@ -388,9 +417,11 @@ export default function FormCurso({ initial = {}, onSaved, auth }) {
         <button type="button" className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition" onClick={() => navigate(-1)}>
           Cancelar
         </button>
-        <button type="submit" disabled={busy} className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition disabled:opacity-60">
-          {busy ? 'Guardando...' : 'Guardar'}
-        </button>
+        {(!isLocked || initial.estado === 'inactivo' || user?.rol === 'admin') && (
+          <button type="submit" disabled={busy} className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition disabled:opacity-60">
+            {busy ? 'Guardando...' : 'Guardar'}
+          </button>
+        )}
       </div>
     </form>
   );

--- a/Frontend/src/modules/cursos/TablaCursos.jsx
+++ b/Frontend/src/modules/cursos/TablaCursos.jsx
@@ -200,7 +200,8 @@ export default function TablaCursos({ onEdit, showInactive = false }) {
                   </div>
 
                   <div className="pt-4 border-t border-gray-100 flex gap-2 flex-wrap">
-                    {!isFinalized && (
+                    {/* Restriction: Responsable CANNOT Edit Active Courses */}
+                    {(!(!showInactive && user?.rol === 'responsable')) && !isFinalized && (
                       <button onClick={() => onEdit(r)} className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition flex items-center justify-center gap-2 ${showInactive ? 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200' : 'bg-blue-50 text-blue-700 hover:bg-blue-100'}`}>
                         <HiOutlinePencil className="w-4 h-4" />
                         {showInactive ? 'Completar Info' : 'Editar'}
@@ -214,7 +215,13 @@ export default function TablaCursos({ onEdit, showInactive = false }) {
                     ) : (
                       <div className="flex items-center gap-2 justify-center py-2 px-3">
                         <span className="text-sm font-medium text-gray-600">Estado:</span>
-                        <Switch checked={true} onChange={() => confirmDelete(r.id_curso)} color="green" />
+                        {/* Restriction: Responsable CANNOT Deactivate Active Courses */}
+                        <Switch
+                          checked={true}
+                          onChange={() => confirmDelete(r.id_curso)}
+                          color="green"
+                          disabled={user?.rol === 'responsable'}
+                        />
                       </div>
                     )}
                     {!showInactive && !isFinalized && (


### PR DESCRIPTION
## 📋 Descripción del cambio
Se corrigieron restricciones para cursos:
Encargado NO puede deshabilitar ni modificar cursos una vez guardados.
Administrador puede activar, desactivar y modificar solo cursos habilitados.
Reglas de curso solo modificables cuando el curso está inhabilitado.

---

### 🔄 Tipo de cambio
- [ ] Nueva funcionalidad
- [X] Corrección de error
- [ ] Mejora existente
- [ ] Documentación

---

### 🔗 Issue relacionado
Closes #37 

---

### 🧠 Checklist
- [X] Probado localmente
- [X] Sigue las convenciones de commits
- [ ] Revisado por otro compañero
- [X] Cumple con las reglas del comité de cambio (si aplica)
